### PR TITLE
Add a transactional Erased wrapper for Content types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "kelvin"
 repository = "https://github.com/dusk-network/kelvin"
 description = "Merkle tree tooklit and backend"
 keywords = ["merkle", "datastructure", "database"]
-version = "0.18.0"
+version = "0.19.0"
 license = "MPL-2.0"
 
 [dependencies]

--- a/src/annotations/mod.rs
+++ b/src/annotations/mod.rs
@@ -74,23 +74,23 @@ where
 
 /// Empty annotation
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub struct VoidAnnotation;
+pub struct Void;
 
-impl<T> From<&T> for VoidAnnotation {
+impl<T> From<&T> for Void {
     fn from(_: &T) -> Self {
-        VoidAnnotation
+        Void
     }
 }
 
-impl Associative for VoidAnnotation {
+impl Associative for Void {
     fn op(&mut self, _: &Self) {}
 }
 
-impl<H: ByteHash> Content<H> for VoidAnnotation {
+impl<H: ByteHash> Content<H> for Void {
     fn persist(&mut self, _: &mut Sink<H>) -> io::Result<()> {
         Ok(())
     }
     fn restore(_: &mut Source<H>) -> io::Result<Self> {
-        Ok(VoidAnnotation)
+        Ok(Void)
     }
 }

--- a/src/erased.rs
+++ b/src/erased.rs
@@ -1,0 +1,213 @@
+use std::io::{self, Read, Write};
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+
+use bytehash::ByteHash;
+
+use crate::content::Content;
+use crate::store::Store;
+use crate::{Sink, Source};
+
+/// A type-erased snapshot of a Compound structure.
+///
+/// Can be used to hide type parameters in complex type definitions
+/// and acts as a kind of `Any` type for other types implementing `Content`
+#[derive(Clone)]
+pub struct Erased<H: ByteHash> {
+    hash: H::Digest,
+    store: Store<H>,
+}
+
+/// Type representing a query over an `Erased` wrapper
+pub struct Query<T, H> {
+    inner: T,
+    _marker: PhantomData<H>,
+}
+
+/// Type representing a transaction in progress over an `Erased` wrapper
+pub struct Transaction<'a, T, H>
+where
+    H: ByteHash,
+{
+    inner: T,
+    store: Store<H>,
+    commit: &'a mut H::Digest,
+}
+
+impl<T, H> Deref for Query<T, H>
+where
+    H: ByteHash,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<'a, T, H> Deref for Transaction<'a, T, H>
+where
+    H: ByteHash,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<'a, T, H> DerefMut for Transaction<'a, T, H>
+where
+    H: ByteHash,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<'a, T, H> Transaction<'a, T, H>
+where
+    H: ByteHash,
+    T: Content<H>,
+{
+    /// Commits the transaction to the underlying `Erased` wrapper
+    pub fn commit(&mut self) -> io::Result<()> {
+        *self.commit = self.store.persist(&mut self.inner)?.into_hash();
+        Ok(())
+    }
+}
+
+impl<H> Erased<H>
+where
+    H: ByteHash,
+{
+    /// Construct a new wrapper for the default value of `T`
+    pub fn new<T: Content<H> + Default>(store: &Store<H>) -> io::Result<Self> {
+        Self::wrap(T::default(), store)
+    }
+
+    /// Construct a new erased wrapper of T
+    pub fn wrap<T: Content<H>>(mut t: T, store: &Store<H>) -> io::Result<Self> {
+        let store = store.clone();
+        let snap = store.persist(&mut t)?;
+        Ok(Erased {
+            hash: snap.into_hash(),
+            store,
+        })
+    }
+
+    /// Constructs a read-only query over the type in the `Erased` wrapper
+    pub fn query<T>(&self) -> io::Result<Query<T, H>>
+    where
+        T: Content<H>,
+    {
+        let inner = self.store.get_hash(&self.hash)?;
+        Ok(Query {
+            inner,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Constructs a transaction for the type in the `Erased` wrapper
+    pub fn transaction<T>(&mut self) -> io::Result<Transaction<T, H>>
+    where
+        T: Content<H>,
+    {
+        let inner = self.store.get_hash(&self.hash)?;
+        Ok(Transaction {
+            inner,
+            store: self.store.clone(),
+            commit: &mut self.hash,
+        })
+    }
+}
+
+impl<H> Content<H> for Erased<H>
+where
+    H: ByteHash,
+{
+    fn persist(&mut self, sink: &mut Sink<H>) -> io::Result<()> {
+        sink.write_all(self.hash.as_ref())
+    }
+
+    fn restore(source: &mut Source<H>) -> io::Result<Self> {
+        let mut hash = H::Digest::default();
+        source.read_exact(hash.as_mut())?;
+        Ok(Erased {
+            hash,
+            store: source.store().clone(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bytehash::Blake2b;
+
+    #[test]
+    fn erased_u32() {
+        let store = Store::<Blake2b>::ephemeral();
+
+        let i = 77u32;
+
+        let mut erased = Erased::wrap(i, &store).unwrap();
+
+        assert_eq!(*erased.query::<u32>().unwrap(), 77);
+
+        let mut trans = erased.transaction::<u32>().unwrap();
+        *trans += 1;
+        trans.commit().unwrap();
+
+        assert_eq!(*erased.query::<u32>().unwrap(), 78);
+    }
+
+    #[derive(Clone)]
+    struct Double<H>
+    where
+        H: ByteHash,
+    {
+        a: Erased<H>,
+        b: Erased<H>,
+    }
+
+    impl<H> Content<H> for Double<H>
+    where
+        H: ByteHash,
+    {
+        fn persist(&mut self, sink: &mut Sink<H>) -> io::Result<()> {
+            self.a.persist(sink)?;
+            self.b.persist(sink)
+        }
+
+        fn restore(source: &mut Source<H>) -> io::Result<Self> {
+            Ok(Double {
+                a: Erased::restore(source)?,
+                b: Erased::restore(source)?,
+            })
+        }
+    }
+
+    #[test]
+    fn double_wrapped() {
+        let store = Store::<Blake2b>::ephemeral();
+
+        let mut double = Double {
+            a: Erased::wrap(13u32, &store).unwrap(),
+            b: Erased::wrap(14u32, &store).unwrap(),
+        };
+
+        let snapshot = store.persist(&mut double).unwrap();
+
+        let mut restored = store.restore(&snapshot).unwrap();
+
+        assert_eq!(*restored.a.query::<u32>().unwrap(), 13);
+        assert_eq!(*restored.b.query::<u32>().unwrap(), 14);
+
+        let mut trans = restored.b.transaction::<u32>().unwrap();
+        *trans = 12;
+        trans.commit().unwrap();
+
+        assert_eq!(*restored.b.query::<u32>().unwrap(), 12);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ mod branch;
 mod compound;
 mod content;
 mod debug_draw;
+mod erased;
 mod handle;
 mod iter;
 mod map;
@@ -24,13 +25,14 @@ mod source;
 mod store;
 
 pub use crate::annotations::{
-    Annotation, Associative, Combine, ErasedAnnotation, VoidAnnotation,
+    Annotation, Associative, Combine, ErasedAnnotation, Void,
 };
 pub use crate::backend::Backend;
 pub use crate::branch::{Branch, BranchMut};
 pub use crate::compound::Compound;
 pub use crate::content::Content;
 pub use crate::debug_draw::{DebugDraw, DrawState};
+pub use crate::erased::{Erased, Query, Transaction};
 pub use crate::handle::{
     Handle, HandleMut, HandleMutLeaf, HandleMutNode, HandleMutNone, HandleRef,
     HandleType,

--- a/src/store.rs
+++ b/src/store.rs
@@ -61,12 +61,17 @@ impl<T: Content<H>, H: ByteHash> Snapshot<T, H> {
         &self.hash
     }
 
+    /// Unwraps the snapshot returning the hash.
+    pub fn into_hash(self) -> H::Digest {
+        self.hash
+    }
+
     pub(crate) fn as_bytes(&self) -> &[u8] {
         self.hash.as_ref()
     }
 }
 
-impl<N, H: ByteHash> Deref for Snapshot<N, H> {
+impl<T, H: ByteHash> Deref for Snapshot<T, H> {
     type Target = H::Digest;
     fn deref(&self) -> &Self::Target {
         &self.hash

--- a/structures/hamt/Cargo.toml
+++ b/structures/hamt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kelvin-hamt"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 repository = "https://github.com/dusk-network/kelvin"
@@ -9,4 +9,4 @@ description = "HAMT Data structure"
 license = "MPL-2.0"
 
 [dependencies]
-kelvin = { path = "../..", version = "0.18" }
+kelvin = { path = "../..", version = "0.19" }

--- a/structures/radix/Cargo.toml
+++ b/structures/radix/Cargo.toml
@@ -6,7 +6,7 @@ license = "MPL-2.0"
 name = "kelvin-radix"
 repository = "https://github.com/dusk-network/kelvin"
 keywords = ["datastructure", "kelvin"]
-version = "0.10.0"
+version = "0.11.0"
 
 [dependencies]
-kelvin = { path = "../..", version = "0.18" }
+kelvin = { path = "../..", version = "0.19" }

--- a/structures/radix/src/lib.rs
+++ b/structures/radix/src/lib.rs
@@ -9,7 +9,7 @@ mod nibbles;
 use nibbles::{AsNibbles, NibbleBuf, Nibbles};
 
 use kelvin::{
-    annotations::{Annotation, VoidAnnotation},
+    annotations::{Annotation, Void},
     ByteHash, Compound, Content, Handle, HandleMut, HandleType, Method,
     SearchResult, Sink, Source, ValPath, ValPathMut,
 };
@@ -19,7 +19,7 @@ const N_BUCKETS: usize = 17;
 const MAX_KEY_LEN: usize = core::u16::MAX as usize / 2;
 
 /// Default unannotated Radix trie
-pub type DefaultRadixMap<K, V, H> = Radix<K, V, VoidAnnotation, H>;
+pub type DefaultRadixMap<K, V, H> = Radix<K, V, Void, H>;
 
 /// A Prefix tree
 pub struct Radix<K, V, A, H>
@@ -414,7 +414,7 @@ mod test {
 
     #[test]
     fn trivial_map() {
-        let mut h = Radix::<_, _, VoidAnnotation, Blake2b>::new();
+        let mut h = Radix::<_, _, Void, Blake2b>::new();
         h.insert(String::from("hello"), String::from("world"))
             .unwrap();
         assert_eq!(*h.get("hello").unwrap().unwrap(), "world");
@@ -422,7 +422,7 @@ mod test {
 
     #[test]
     fn bigger_map() {
-        let mut h = Radix::<_, _, VoidAnnotation, Blake2b>::new();
+        let mut h = Radix::<_, _, Void, Blake2b>::new();
         for i in 0u16..1024 {
             let b = i.to_be_bytes();
             assert_eq!(h.insert(b, i).unwrap(), None);
@@ -433,7 +433,7 @@ mod test {
 
     #[test]
     fn insert_remove() {
-        let mut h = Radix::<_, _, VoidAnnotation, Blake2b>::new();
+        let mut h = Radix::<_, _, Void, Blake2b>::new();
         let n = 1024;
         for i in 0u16..n {
             let b = i.to_be_bytes();
@@ -457,7 +457,7 @@ mod test {
             keys[i as usize] = key;
         }
 
-        let mut h = Radix::<_, _, VoidAnnotation, Blake2b>::new();
+        let mut h = Radix::<_, _, Void, Blake2b>::new();
         for key in keys.iter() {
             let b = key.to_be_bytes();
             h.insert(b, *key).unwrap();
@@ -481,7 +481,7 @@ mod test {
             "",
         ];
 
-        let mut h = Radix::<_, _, VoidAnnotation, Blake2b>::new();
+        let mut h = Radix::<_, _, Void, Blake2b>::new();
 
         for i in 0..keys.len() {
             h.insert(keys[i], i as u16).unwrap();
@@ -494,7 +494,7 @@ mod test {
 
     #[test]
     fn splitting() {
-        let mut h = Radix::<_, _, VoidAnnotation, Blake2b>::new();
+        let mut h = Radix::<_, _, Void, Blake2b>::new();
         h.insert(vec![0x00, 0x00], 0).unwrap();
         assert_eq!(h.insert(vec![0x00, 0x00], 0).unwrap(), Some(0));
         h.insert(vec![0x00, 0x10], 8).unwrap();
@@ -505,7 +505,7 @@ mod test {
 
     #[test]
     fn borrowed_keys() {
-        let mut map = Radix::<String, u8, VoidAnnotation, Blake2b>::new();
+        let mut map = Radix::<String, u8, Void, Blake2b>::new();
         map.insert("hello".into(), 8).unwrap();
         assert_eq!(*map.get("hello").unwrap().unwrap(), 8);
         assert_eq!(map.remove("hello").unwrap().unwrap(), 8);
@@ -513,7 +513,7 @@ mod test {
 
     #[test]
     fn collapse() {
-        let mut h = Radix::<_, _, VoidAnnotation, Blake2b>::new();
+        let mut h = Radix::<_, _, Void, Blake2b>::new();
         h.insert(vec![0x00, 0x00], 0).unwrap();
         h.insert(vec![0x00, 0x10], 0).unwrap();
 

--- a/structures/two3/Cargo.toml
+++ b/structures/two3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kelvin-two3"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 repository = "https://github.com/dusk-network/kelvin"
@@ -9,5 +9,5 @@ license = "MPL-2.0"
 description = "2-3 Tree Data structure"
 
 [dependencies]
-kelvin = { path = "../..", version = "0.18"  }
+kelvin = { path = "../..", version = "0.19"  }
 arrayvec = "0.5"

--- a/tests/proof.rs
+++ b/tests/proof.rs
@@ -1,11 +1,11 @@
-use kelvin::{Blake2b, Compound, VoidAnnotation, KV};
+use kelvin::{Blake2b, Compound, Void, KV};
 use kelvin_hamt::{HAMTSearch, NarrowHAMT};
 
 #[test]
 fn merkle_proof() {
     use kelvin::Proof;
 
-    let mut hamt = NarrowHAMT::<_, _, VoidAnnotation, Blake2b>::new();
+    let mut hamt = NarrowHAMT::<_, _, Void, Blake2b>::new();
 
     let n = 16;
 

--- a/tests/root_hash.rs
+++ b/tests/root_hash.rs
@@ -1,9 +1,9 @@
-use kelvin::{Blake2b, Compound, Store, VoidAnnotation};
+use kelvin::{Blake2b, Compound, Store, Void};
 use kelvin_hamt::HAMT;
 
 #[test]
 fn root_hash() {
-    let mut hamt = HAMT::<_, _, VoidAnnotation, Blake2b>::new();
+    let mut hamt = HAMT::<_, _, Void, Blake2b>::new();
 
     for i in 0..1024 {
         hamt.insert(i, i).unwrap();


### PR DESCRIPTION
In order to save for example arbitrary contract state in a blockchain, you need to hide the inner types of each contract behind an opaque wrapper that only depends on the hash function.

Queries and Transactions can then be constructed over the erased value, given any type that can deserialize from the stored data.