### PR TITLE
Make annotation macro derive Canon

### DIFF
--- a/src/annotations/annotation_macro.rs
+++ b/src/annotations/annotation_macro.rs
@@ -17,15 +17,12 @@ macro_rules! annotation {
         use std::borrow::Borrow as __Borrow;
         use $crate::annotations::ErasedAnnotation as __ErasedAnnotation;
         use $crate::annotations::Combine as __Combine;
-        use $crate::{
-            Content as __Content,
-            Sink as __Sink,
-            Source as __Source,
-        };
+        use canonical::Canon as Canon;
+        use canonical_derive::Canon as Canon;
 
-        use canonical::Store as __Store;
 
         $(#[$outer])*
+        #[derive(Canon)]
         $pub struct $struct_name $( < $( $param ),* > )* {
             $ ( $ann_key : $ann_type ),*
         }
@@ -41,26 +38,6 @@ macro_rules! annotation {
                 $struct_name {
                     $( $ann_key : t.into() ),*
                 }
-            }
-        }
-
-        impl<H, $( $( $param ),* )* > __Content<S> for $struct_name $( < $( $param ),* > )*
-        where
-            H: __ByteHash,
-            $( $ann_type : __Content<S> ),*
-            $( , $( $whereclause )* )?
-
-        {
-            fn persist(&mut self, sink: &mut __Sink<S>) -> io::Result<()> {
-                $( self.$ann_key.persist(sink)? ; )*
-                Ok(())
-            }
-
-            fn restore(source: &mut __Source<S>) -> io::Result<Self> {
-                Ok($struct_name {
-                    $( $ann_key : < $ann_type as __Content<S> >::restore(source)? , )*
-                })
-
             }
         }
 

--- a/src/raw_branch.rs
+++ b/src/raw_branch.rs
@@ -401,7 +401,8 @@ where
             if !self.levels.is_empty() {
                 if let NodeRef::Owned(o) = popped.node {
                     let last = self.levels.last_mut().expect("length < 1");
-                    last.insert_child(*o);
+                    // FIXME: Should we handle this error? Or simply omit it?
+                    let _ = last.insert_child(*o);
                 }
             }
             true

--- a/src/raw_branch.rs
+++ b/src/raw_branch.rs
@@ -401,8 +401,7 @@ where
             if !self.levels.is_empty() {
                 if let NodeRef::Owned(o) = popped.node {
                     let last = self.levels.last_mut().expect("length < 1");
-                    // FIXME: Should we handle this error? Or simply omit it?
-                    let _ = last.insert_child(*o);
+                    last.insert_child(*o);
                 }
             }
             true


### PR DESCRIPTION
In order to have Generic and easy-to-implement
`Anotations` which use Canon-derived structures inside, we needed
to have the `Canon` trait implemented for them.

Now the macro derives the Canon trait correctly and it is working
for poseidon252::PoseidonAnnotation which is generated using this
exact macro.

Also the implementation of `Content` has been removed since the
trait has been deprecated.

Helps to finish with #50 and allows us to implement Canon for all of the Poseidon252 repo as can be seen in: https://github.com/dusk-network/Poseidon252/pull/80